### PR TITLE
Fix path in postCreate script to correctly copy welcome message to fi…

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -2,4 +2,5 @@
 # This script is run after the container is created.
 # It is used to install any additional dependencies or perform any setup tasks.
 
+sudo mkdir -p /usr/local/etc/vscode-dev-containers
 sudo cp --force ./.devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -2,4 +2,4 @@
 # This script is run after the container is created.
 # It is used to install any additional dependencies or perform any setup tasks.
 
-sudo cp --force ./.devcontainer/welcome-message.txt /local/etc/vscode-dev-containers/first-run-notice.txt
+sudo cp --force ./.devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.devcontainer/postCreate.sh` script. The change updates the destination path for copying the `welcome-message.txt` file.

* [`.devcontainer/postCreate.sh`](diffhunk://#diff-97be9c522d9f33bfb996fb6e208e43d8686a6b8fe8b69c5fd28552c903e57d3dL5-R5): Changed the destination path for the `welcome-message.txt` file from `/local/etc/vscode-dev-containers/` to `/usr/local/etc/vscode-dev-containers/`.