### PR TITLE
Update postCreateCommand in devcontainer.json to use sudo for script …

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/universal:2-linux
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment if you want to install more global node packages
-# RUN su vscode -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,5 @@
         }
     },
     "forwardPorts": [],
-    "postCreateCommand": "chmod +x ./.devcontainer/postCreate.sh && bash ./.devcontainer/postCreate.sh"
+    "postCreateCommand": "sudo chmod +x ./.devcontainer/postCreate.sh && bash ./.devcontainer/postCreate.sh"
 }


### PR DESCRIPTION
This pull request makes updates to the development container configuration by removing the Dockerfile and adjusting the `postCreateCommand` in the `devcontainer.json` file.

Changes to development container configuration:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L1-L8): Removed the Dockerfile, which previously defined the base image and included commented-out examples for installing additional OS and Node.js packages.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L29-R29): Updated the `postCreateCommand` to include `sudo` for modifying permissions on the `postCreate.sh` script, ensuring the command runs successfully in environments requiring elevated privileges.